### PR TITLE
Provide built-in aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,10 @@ Simply add these things to your **package.json**. All scripts (a.k.a., commands)
   },
   "scripts": {
     "build": "xs build",
-    "clean": "xs clean",
-    "deploy": "xs deploy",
     "docs": "xs docs",
-    "lint": "xs lint",
     "release": "xs release",
-    "serve": "xs serve",
+    "start": "xs serve",
     "test": "xs test",
-    "types": "xs types",
     "watch": "xs watch"
   },
   "devDependencies": {
@@ -52,21 +48,27 @@ Simply add these things to your **package.json**. All scripts (a.k.a., commands)
 
 | Command | Description |
 |---|---|
-| `build` | Build `dist` and `lib` targets in release mode as well as the types. |
+| `build` | Alias for `clean,lint,types,bundle` |
+| `bump` | Interactive prompt to bump the version number |
+| `bundle` | Build `dist` and `lib` targets in release mode as well as the types. |
 | `clean` | Removes the `dist` and `lib` folders |
-| `deploy` | Does `build` and `docs` and then copies the folders (`dist`, `examples`, `docs`) to `gh-pages` branch |
+| `deploy` | Alias for `build,docs,upload` |
 | `docs` | Build the `src` folder into `docs` folder using webdoc |
+| `git-push` | Does `git push` and `git push --tags` |
 | `lint` | Using ESLint to lint the `src` folder. This supports additional CLI arguments to pass to ESLint, for instance `xs lint -- --fix` |
 | `pack` | Like `npm pack` but will use [clean-package](https://www.npmjs.com/package/clean-package) |
-| `release` | Publish a release, will ask for what type of version bump, do a `deploy` and push to npm and git tags. |
+| `publish` | Just like `npm publish` but invokes `clean-package` before and after |
+| `release` | Alias for `bump,test,deploy,publish,git-push` |
 | `serve` | Runs `watch` command plus also opens the `examples` folder |
 | `test` | Run the unit tests in the `test` folder. This supports additional CLI arguments to pass to Jest, for instance `xs test -- --ci` |
 | `types` | Type-check the `src` folder using TypeScript |
+| `upload` | Upload files to gh-pages branch |
+| `version` | Output the version of `@pixi/extension-scripts` |
 | `watch` | Watch the code in development mode, updates on changes |
 
 ### Chaining
 
-Commands can also be chained together easily separated by a comma. For example, the following will serially call `test`, `build`, then finally `docs`. This can be used as a convenient shortcut for `pre*` and `post*` **package.json** scripts.
+Commands can also be chained together easily separated by a comma. For example, the following will serially call `test`, `build`, then finally `docs`. This can be used as a convenient alternative for `pre*` and `post*` **package.json** scripts.
 
 ```json
 {
@@ -121,6 +123,7 @@ Configuration can be provided using the `extensionConfig` field in **package.jso
   "extensionConfig": {
     "namespace": "PIXI.myextension",
     "bundle": "dist/pixi-my-extension.js",
+    "bundleModule": "dist/pixi-my-extension.mjs",
     "globals": {
         "lodash": "_"
     }

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -18,7 +18,7 @@ const scriptsPkg = JSON.parse(await promises.readFile(
 ));
 
 /** Build the project using Rollup */
-const build = (...args) =>
+const bundle = (...args) =>
 {
     const rollupConfig = path.join(__dirname, 'configs/rollup.mjs');
 
@@ -93,7 +93,7 @@ const test = async (additionalArgs) =>
 };
 
 /** Export the types */
-const buildTypes = () => tsc(
+const bundleTypes = () => tsc(
     '--outDir', path.join(process.cwd(), 'lib'),
     '--declaration',
     '--emitDeclarationOnly'
@@ -155,14 +155,6 @@ const lint = async (additionalArgs = []) =>
     });
 };
 
-/** Deploy everything to gh-pages */
-const deploy = () => spawn('gh-pages', [
-    '-d', '.',
-    '-b', extensionConfig.deployBranch,
-    '-s', extensionConfig.deployFiles,
-    '-f',
-]);
-
 /** Open the exmaples folder */
 const serve = async () =>
 {
@@ -172,7 +164,7 @@ const serve = async () =>
         process.exit(1);
     }
 
-    return spawn('http-server', [
+    spawn('http-server', [
         '.',
         '-a', 'localhost',
         '-o', extensionConfig.serve,
@@ -208,23 +200,43 @@ const cleanPackage = async (...args) =>
 
 /** Supported commands */
 const Command = {
-    Watch: 'watch',
-    Clean: 'clean',
-    Lint: 'lint',
-    Types: 'types',
     Build: 'build',
+    Bump: 'bump',
+    Bundle: 'bundle',
+    Clean: 'clean',
     Deploy: 'deploy',
-    Serve: 'serve',
-    Release: 'release',
-    Version: 'version',
-    Test: 'test',
     Docs: 'docs',
+    GitPush: 'git-push',
+    Lint: 'lint',
     Pack: 'pack',
+    Publish: 'publish',
+    Release: 'release',
+    Serve: 'serve',
+    Test: 'test',
+    Types: 'types',
+    Upload: 'upload',
+    Version: 'version',
+    Watch: 'watch',
+};
+
+/** Workflow tasks */
+const Aliases = {
+    [Command.Build]: 'clean,lint,types,bundle',
+    [Command.Deploy]: 'build,docs,upload',
+    [Command.Release]: 'bump,test,deploy,publish,git-push',
 };
 
 /** Run one of the commands above */
 const runCommand = async (command, additionalArgs) =>
 {
+    // Check for aliases
+    if (Aliases[command])
+    {
+        await runCommand(Aliases[command], additionalArgs);
+
+        return;
+    }
+
     // Support for chaining commands, for example: "build,docs,test"
     if (command.includes(','))
     {
@@ -240,64 +252,7 @@ const runCommand = async (command, additionalArgs) =>
 
     switch (command)
     {
-        case Command.Version: {
-            // eslint-disable-next-line no-console
-            console.log(`v${scriptsPkg.version}`);
-            break;
-        }
-        case Command.Watch: {
-            await build('-w');
-            break;
-        }
-        case Command.Clean: {
-            await spawn('rimraf', [
-                '{dist,lib}/*',
-                ...extensionConfig.clean,
-            ]);
-            break;
-        }
-        case Command.Lint: {
-            await lint(additionalArgs);
-            break;
-        }
-        case Command.Types: {
-            await tsc('-noEmit');
-            break;
-        }
-        case Command.Build: {
-            await runCommand(Command.Clean);
-            await runCommand(Command.Types);
-            await lint();
-            await build();
-            await buildTypes();
-            await fixGlobalTypes();
-            break;
-        }
-        case Command.Pack: {
-            await cleanPackage();
-            await spawn('npm', ['pack']);
-            await cleanPackage('restore');
-            break;
-        }
-        case Command.Deploy: {
-            await runCommand(Command.Build);
-            await runCommand(Command.Docs);
-            await deploy();
-            break;
-        }
-        case Command.Serve: {
-            serve().then(() => build('-w'));
-            break;
-        }
-        case Command.Docs: {
-            await docs();
-            break;
-        }
-        case Command.Test: {
-            await test(additionalArgs);
-            break;
-        }
-        case Command.Release: {
+        case Command.Bump: {
             const { bump, custom } = await inquirer.prompt([{
                 name: 'bump',
                 type: 'list',
@@ -310,16 +265,61 @@ const runCommand = async (command, additionalArgs) =>
                 when: (answers) => answers.bump === 'custom',
             }]);
 
-            await runCommand(Command.Test, []);
             await spawn('npm', ['version', bump === 'custom' ? custom : bump]);
-            await runCommand(Command.Deploy);
+            break;
+        }
+        case Command.Bundle: {
+            await bundle();
+            await bundleTypes();
+            await fixGlobalTypes();
+
+            break;
+        }
+        case Command.Clean: {
+            await spawn('rimraf', [
+                '{dist,lib}/*',
+                ...extensionConfig.clean,
+            ]);
+            break;
+        }
+        case Command.Docs: await docs(); break;
+        case Command.GitPush: {
+            await spawn('git', ['push']);
+            await spawn('git', ['push', '--tags']);
+
+            break;
+        }
+        case Command.Lint: await lint(additionalArgs); break;
+        case Command.Pack: {
+            await cleanPackage();
+            await spawn('npm', ['pack']);
+            await cleanPackage('restore');
+            break;
+        }
+        case Command.Publish: {
             await cleanPackage();
             await spawn('npm', ['publish']);
             await cleanPackage('restore');
-            await spawn('git', ['push']);
-            await spawn('git', ['push', '--tags']);
             break;
         }
+        case Command.Serve: serve().then(() => runCommand(Command.Watch)); break;
+        case Command.Test: await test(additionalArgs); break;
+        case Command.Types: await tsc('-noEmit'); break;
+        case Command.Upload: {
+            await spawn('gh-pages', [
+                '-d', '.',
+                '-b', extensionConfig.deployBranch,
+                '-s', extensionConfig.deployFiles,
+                '-f',
+            ]);
+            break;
+        }
+        case Command.Version: {
+            // eslint-disable-next-line no-console
+            console.log(`v${scriptsPkg.version}`);
+            break;
+        }
+        case Command.Watch: bundle('-w'); break;
         default: {
             // eslint-disable-next-line no-console
             console.error(chalk.red(`${prefix} Error: Unknown command "${command}". `

--- a/test/examples/index.html
+++ b/test/examples/index.html
@@ -5,7 +5,7 @@
 </head>
 <body>
   <script src="https://pixijs.download/dev/pixi.min.js"></script>
-  <script src="../dist/pixi-extension-scripts-test.js"></script>
+  <script src="../dist/pixi-my-system.js"></script>
   <script>
     const app = new PIXI.Application();
     document.body.appendChild(app.view);

--- a/test/package.json
+++ b/test/package.json
@@ -13,17 +13,15 @@
     }
   },
   "scripts": {
-    "clean": "xs clean",
-    "watch": "xs watch",
     "build": "xs build",
-    "lint": "xs lint",
+    "clean": "xs clean",
     "docs": "xs docs",
-    "types": "xs types",
+    "lint": "xs lint",
     "serve": "xs serve",
-    "deploy": "xs deploy",
-    "release": "xs release",
+    "test": "xs build,docs,test",
+    "types": "xs types",
     "unit-test": "xs test",
-    "test": "xs build,docs,test"
+    "watch": "xs watch"
   },
   "peerDependencies": {
     "@pixi/core": "^7.0.0"


### PR DESCRIPTION
Provide more flexibility by deconstructing `release`, `deploy` and `build` commands into aliases. 

| Alias | Commands |
|---|---|
| `build` | `clean,lint,types,bundle` |
| `deploy` | `build,docs,upload` |
| `release` | `bump,test,deploy,publish,git-push` |

This should make it easier, for instance to build without type checking (`clean,lint,bundle`) or release without pushing git tags or testing (`bump,deploy,publish`).