### PR TITLE
Prevent rollup from bundling anything @pixi/*

### DIFF
--- a/lib/configs/rollup.mjs
+++ b/lib/configs/rollup.mjs
@@ -18,65 +18,70 @@ const banner = [
     ` */`,
 ].join('\n');
 
-const pixiPackages = [
-    'accessibility',
-    'app',
-    'assets',
-    'basis',
-    'canvas-display',
-    'canvas-extract',
-    'canvas-graphics',
-    'canvas-mesh',
-    'canvas-particle-container',
-    'canvas-renderer',
-    'canvas-prepare',
-    'canvas-sprite',
-    'canvas-sprite-tiling',
-    'canvas-text',
-    'compressed-textures',
-    'core',
-    'display',
-    'events',
-    'extensions',
-    'extract',
-    'graphics-extras',
-    'graphics',
-    'math-extras',
-    'math',
-    'mesh-extras',
-    'mesh',
-    'mixin-cache-as-bitmap',
-    'mixin-get-child-by-name',
-    'mixin-get-global-position',
-    'particle-container',
-    'prepare',
-    'runner',
-    'settings',
-    'sprite-animated',
-    'sprite-tiling',
-    'sprite',
-    'spritesheet',
-    'text-bitmap',
-    'text',
-    'ticker',
-    'unsafe-eval',
-];
+const builtInPackages = {
+    '@pixi/accessibility': 'PIXI',
+    '@pixi/app': 'PIXI',
+    '@pixi/assets': 'PIXI',
+    '@pixi/basis': 'PIXI',
+    '@pixi/canvas-display': 'PIXI',
+    '@pixi/canvas-extract': 'PIXI',
+    '@pixi/canvas-graphics': 'PIXI',
+    '@pixi/canvas-mesh': 'PIXI',
+    '@pixi/canvas-particle-container': 'PIXI',
+    '@pixi/canvas-renderer': 'PIXI',
+    '@pixi/canvas-prepare': 'PIXI',
+    '@pixi/canvas-sprite': 'PIXI',
+    '@pixi/canvas-sprite-tiling': 'PIXI',
+    '@pixi/canvas-text': 'PIXI',
+    '@pixi/compressed-textures': 'PIXI',
+    '@pixi/core': 'PIXI',
+    '@pixi/display': 'PIXI',
+    '@pixi/events': 'PIXI',
+    '@pixi/extensions': 'PIXI',
+    '@pixi/extract': 'PIXI',
+    // In PixiJS 7.1.0+ filters namespace was removed, but we'll
+    // keep it here for backwards compatibility
+    '@pixi/filter-alpha': 'PIXI.filters',
+    '@pixi/filter-blur': 'PIXI.filters',
+    '@pixi/filter-color-matrix': 'PIXI.filters',
+    '@pixi/filter-displacement': 'PIXI.filters',
+    '@pixi/filter-fxaa': 'PIXI.filters',
+    '@pixi/filter-noise': 'PIXI.filters',
+    '@pixi/graphics-extras': 'PIXI',
+    '@pixi/graphics': 'PIXI',
+    '@pixi/math-extras': 'PIXI',
+    '@pixi/math': 'PIXI',
+    '@pixi/mesh-extras': 'PIXI',
+    '@pixi/mesh': 'PIXI',
+    '@pixi/mixin-cache-as-bitmap': 'PIXI',
+    '@pixi/mixin-get-child-by-name': 'PIXI',
+    '@pixi/mixin-get-global-position': 'PIXI',
+    '@pixi/particle-container': 'PIXI',
+    '@pixi/prepare': 'PIXI',
+    '@pixi/runner': 'PIXI',
+    '@pixi/settings': 'PIXI',
+    '@pixi/sprite-animated': 'PIXI',
+    '@pixi/sprite-tiling': 'PIXI',
+    '@pixi/sprite': 'PIXI',
+    '@pixi/spritesheet': 'PIXI',
+    '@pixi/text-bitmap': 'PIXI',
+    '@pixi/text': 'PIXI',
+    '@pixi/ticker': 'PIXI',
+    '@pixi/unsafe-eval': 'PIXI',
+    '@pixi/utils': 'PIXI.utils',
+};
 
 // External dependencies, not bundled
-const external = pixiPackages.map((name) => `@pixi/${name}`) // @pixi/*
+const external = Object.keys(builtInPackages) // @pixi/*
     .concat(Object.keys(pkg.peerDependencies || {})) // Peer Dependencies
-    .concat(Object.keys(pkg.dependencies || {})) // Dependencies
-    .concat([ // Oddballs
-        '@pixi/utils',
-        '@pixi/filter-alpha',
-        '@pixi/filter-blur',
-        '@pixi/filter-color-matrix',
-        '@pixi/filter-displacement',
-        '@pixi/filter-fxaa',
-        '@pixi/filter-noise',
-    ]);
+    .concat(Object.keys(pkg.dependencies || {})); // Dependencies
 
-const builtInPackages = pixiPackages.reduce((acc, name) => ({ ...acc, [`@pixi/${name}`]: 'PIXI' }), {});
+// These are the PixiJS built-in default globals
+// for the browser bundle when referencing other core packages
+const globals = {
+    ...builtInPackages,
+    ...extensionConfig.globals,
+};
 
 // Plugins for browser-based bundles
 const browserPlugins = [
@@ -95,20 +100,6 @@ const modulePlugins = [
     rename(),
     esbuild({ target: 'ES2020' })
 ];
-
-// These are the PixiJS built-in default globals
-// for the browser bundle when referencing other core packages
-const globals = {
-    '@pixi/utils': 'PIXI.utils',
-    '@pixi/filter-alpha': 'PIXI.filters',
-    '@pixi/filter-blur': 'PIXI.filters',
-    '@pixi/filter-color-matrix': 'PIXI.filters',
-    '@pixi/filter-displacement': 'PIXI.filters',
-    '@pixi/filter-fxaa': 'PIXI.filters',
-    '@pixi/filter-noise': 'PIXI.filters',
-    ...builtInPackages,
-    ...extensionConfig.globals,
-};
 
 const { source } = extensionConfig;
 const basePath = path.dirname(path.join(process.cwd(), source));

--- a/lib/configs/rollup.mjs
+++ b/lib/configs/rollup.mjs
@@ -4,7 +4,6 @@ import esbuild from 'rollup-plugin-esbuild';
 import { extensionConfig, packageInfo as pkg } from '../extensionConfig.mjs';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
-import { builtinModules } from 'node:module';
 
 const compiled = (new Date()).toUTCString().replace(/GMT/g, 'UTC');
 const banner = [

--- a/lib/configs/rollup.mjs
+++ b/lib/configs/rollup.mjs
@@ -4,6 +4,7 @@ import esbuild from 'rollup-plugin-esbuild';
 import { extensionConfig, packageInfo as pkg } from '../extensionConfig.mjs';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
+import { builtinModules } from 'node:module';
 
 const compiled = (new Date()).toUTCString().replace(/GMT/g, 'UTC');
 const banner = [
@@ -18,12 +19,7 @@ const banner = [
     ` */`,
 ].join('\n');
 
-// External dependencies, not bundled
-const external = []
-    .concat(Object.keys(pkg.peerDependencies || {}))
-    .concat(Object.keys(pkg.dependencies || {}));
-
-const builtInPackages = [
+const pixiPackages = [
     'accessibility',
     'app',
     'assets',
@@ -65,7 +61,23 @@ const builtInPackages = [
     'text',
     'ticker',
     'unsafe-eval',
-].reduce((acc, name) => ({ ...acc, [`@pixi/${name}`]: 'PIXI' }), {});
+];
+
+// External dependencies, not bundled
+const external = pixiPackages.map((name) => `@pixi/${name}`) // @pixi/*
+    .concat(Object.keys(pkg.peerDependencies || {})) // Peer Dependencies
+    .concat(Object.keys(pkg.dependencies || {})) // Dependencies
+    .concat([ // Oddballs
+        '@pixi/utils',
+        '@pixi/filter-alpha',
+        '@pixi/filter-blur',
+        '@pixi/filter-color-matrix',
+        '@pixi/filter-displacement',
+        '@pixi/filter-fxaa',
+        '@pixi/filter-noise',
+    ]);
+
+const builtInPackages = pixiPackages.reduce((acc, name) => ({ ...acc, [`@pixi/${name}`]: 'PIXI' }), {});
 
 // Plugins for browser-based bundles
 const browserPlugins = [


### PR DESCRIPTION
By forcing all `@pixi/*` packages to be external, we tell rollup to never ever put pixi code inside an extension. This protects extensions from accidentally duplicating PixiJS code in their bundles.