### PR TITLE
feat(rollup): added version define for esbuild

### DIFF
--- a/lib/configs/rollup.mjs
+++ b/lib/configs/rollup.mjs
@@ -72,6 +72,9 @@ const browserPlugins = [
     commonjs(),
     resolve(),
     esbuild({
+        define: {
+            __VERSION__: JSON.stringify(pkg.version),
+        },
         target: 'ES2017',
         minify: true,
     })
@@ -82,7 +85,7 @@ const modulePlugins = [
     commonjs(),
     resolve(),
     rename(),
-    esbuild({ target: 'ES2020' })
+    esbuild({ define: { __VERSION__: JSON.stringify(pkg.version) }, target: 'ES2020' })
 ];
 
 // These are the PixiJS built-in default globals


### PR DESCRIPTION
Allowing the source to use `"__VERSION__"` and that gets magically replaced by the value inside package.json