### PR TITLE
Feature: Add version string replacement

### DIFF
--- a/lib/configs/rollup.mjs
+++ b/lib/configs/rollup.mjs
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import rename from '@pixi/rollup-plugin-rename-node-modules';
 import esbuild from 'rollup-plugin-esbuild';
+import replace from '@rollup/plugin-replace';
 import { extensionConfig, packageInfo as pkg } from '../extensionConfig.mjs';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
@@ -67,20 +68,25 @@ const builtInPackages = [
     'unsafe-eval',
 ].reduce((acc, name) => ({ ...acc, [`@pixi/${name}`]: 'PIXI' }), {});
 
-// Plugins for browser-based bundles
-const browserPlugins = [
+const basePlugins = [
     commonjs(),
     resolve(),
-    esbuild({
-        target: 'ES2017',
-        minify: true,
-    })
+    replace({
+        preventAssignment: true,
+        delimiters: ['__', '__'],
+        VERSION: pkg.version,
+    }),
+];
+
+// Plugins for browser-based bundles
+const browserPlugins = [
+    ...basePlugins,
+    esbuild({ target: 'ES2017', minify: true })
 ];
 
 // Plugins for module-based output
 const modulePlugins = [
-    commonjs(),
-    resolve(),
+    ...basePlugins,
     rename(),
     esbuild({ target: 'ES2020' })
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@pixi/webdoc-template": "^1.5.5",
         "@rollup/plugin-commonjs": "^24.0.0",
         "@rollup/plugin-node-resolve": "^15.0.1",
+        "@rollup/plugin-replace": "^5.0.2",
         "@types/http-server": "^0.12.1",
         "@types/jest": "^29.2.4",
         "@webdoc/cli": "^2.2.0",
@@ -2607,6 +2608,26 @@
       },
       "peerDependencies": {
         "rollup": "^2.78.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.2.tgz",
+      "integrity": "sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {
@@ -14683,6 +14704,15 @@
         "is-builtin-module": "^3.2.0",
         "is-module": "^1.0.0",
         "resolve": "^1.22.1"
+      }
+    },
+    "@rollup/plugin-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.2.tgz",
+      "integrity": "sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==",
+      "requires": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.27.0"
       }
     },
     "@rollup/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@pixi/webdoc-template": "^1.5.5",
     "@rollup/plugin-commonjs": "^24.0.0",
     "@rollup/plugin-node-resolve": "^15.0.1",
+    "@rollup/plugin-replace": "^5.0.2",
     "@types/http-server": "^0.12.1",
     "@types/jest": "^29.2.4",
     "@webdoc/cli": "^2.2.0",

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -13,6 +13,9 @@ class MySystem implements ISystem
         type: ExtensionType.RendererSystem,
     };
 
+    /** Currention version can be inlined like this: */
+    static version = '__VERSION__';
+
     /** Required init */
     init()
     {


### PR DESCRIPTION
Replaces #9

Allows adding the version into the code as a replacement. For example:

```js
const VERSION = '__VERSION__';
```
becomes:
```js
const VERSION = '1.0.0';
```