### PR TITLE
add pixi.js/pixijs to rollup config

### DIFF
--- a/lib/configs/rollup.mjs
+++ b/lib/configs/rollup.mjs
@@ -20,6 +20,8 @@ const banner = [
 ].join('\n');
 
 const builtInPackages = {
+    'pixi.js': 'PIXI',
+    pixijs: 'PIXI',
     '@pixi/accessibility': 'PIXI',
     '@pixi/app': 'PIXI',
     '@pixi/assets': 'PIXI',


### PR DESCRIPTION
updates the rollup config to make pixi.js and pixijs globals for v8 support