### PR TITLE
Fix: rollup fails to build if you provide no environments

### DIFF
--- a/lib/configs/rollup.mjs
+++ b/lib/configs/rollup.mjs
@@ -126,6 +126,20 @@ if (namespace === 'PIXI')
 }
 
 export default [
+    // Module browser bundle (esm)
+    {
+        external,
+        plugins: browserPlugins,
+        input: extensionConfig.bundleModuleSource ?? source,
+        treeshake: false,
+        output: {
+            banner,
+            file: bundleModule,
+            format: 'esm',
+            sourcemap: true,
+            exports: extensionConfig.bundleModuleExports,
+        },
+    },
     ...!extensionConfig.environments.includes('node') ? [] : [{
         external,
         input: source,
@@ -166,20 +180,6 @@ export default [
             sourcemap: true,
             globals,
             exports: extensionConfig.bundleExports,
-        },
-    },
-    // Module browser bundle (esm)
-    {
-        external,
-        plugins: browserPlugins,
-        input: extensionConfig.bundleModuleSource ?? source,
-        treeshake: false,
-        output: {
-            banner,
-            file: bundleModule,
-            format: 'esm',
-            sourcemap: true,
-            exports: extensionConfig.bundleModuleExports,
         },
     }],
 ];


### PR DESCRIPTION
if you provide `environments: []` as part of the config rollup fails to build