### PR TITLE
Fix non-zero exit codes, env arguments

### DIFF
--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -138,6 +138,14 @@ const lint = async (additionalArgs = []) =>
         await promises.copyFile(path.join(__dirname, 'configs/eslint.json'), eslintrcJson);
     }
 
+    const cleanup = async () =>
+    {
+        if (!isDefined)
+        {
+            await promises.unlink(eslintrcJson);
+        }
+    };
+
     await spawn('eslint', [
         '--ext', '.ts',
         '--ext', '.js',
@@ -145,15 +153,7 @@ const lint = async (additionalArgs = []) =>
         '--no-error-on-unmatched-pattern',
         ...extensionConfig.lint,
         ...additionalArgs,
-    ], {
-        onClose: async () =>
-        {
-            if (!isDefined)
-            {
-                await promises.unlink(eslintrcJson);
-            }
-        }
-    });
+    ], cleanup);
 };
 
 /** Open the exmaples folder */
@@ -181,11 +181,10 @@ const docs = async () =>
     const templateConfig = path.join(__dirname, 'configs/webdoc.json');
     const webdocConfig = path.join(process.cwd(), '.webdoc.json');
     const contents = await promises.readFile(templateConfig, 'utf8');
+    const cleanup = async () => await promises.unlink(webdocConfig);
 
     await promises.writeFile(webdocConfig, template(contents, extensionConfig), 'utf8');
-    await spawn('webdoc', ['-c', webdocConfig], {
-        onClose: async () => await promises.unlink(webdocConfig),
-    });
+    await spawn('webdoc', ['-c', webdocConfig], cleanup);
 };
 
 /** Clean up the package contents */

--- a/lib/utils/spawn.mjs
+++ b/lib/utils/spawn.mjs
@@ -6,9 +6,15 @@ import { prefix } from './prefix.mjs';
 
 const projectPath = path.join(process.cwd());
 
-/** Utility to do spawn but as a Promise */
-export const spawn = (command, args, { onClose, ...options } = {}) =>
-    new Promise((resolve, reject) =>
+/**
+ * Utility to do spawn but as a Promise
+ * @param {string} command - Command to run
+ * @param {string[]} args - Arguments for the command
+ * @param {Function} [onClose] - Function to run when the process closes or errors
+ *        this is useful for cleaning up temporary files even if the process errors.
+ */
+export const spawn = (command, args, onClose) =>
+    new Promise((resolve) =>
     {
         if (!extensionConfig.silent)
         {
@@ -20,10 +26,10 @@ export const spawn = (command, args, { onClose, ...options } = {}) =>
             stdio: 'inherit',
             // See https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows
             shell: process.platform.startsWith('win'),
-            ...options,
+            env: process.env,
         });
 
-        child.on('close', async (code) =>
+        child.once('close', async (code) =>
         {
             await onClose?.();
 
@@ -31,7 +37,16 @@ export const spawn = (command, args, { onClose, ...options } = {}) =>
             {
                 resolve();
             }
+            else
+            {
+                process.exit(code);
+            }
         });
-        child.on('error', reject);
+        child.once('error', async () =>
+        {
+            await onClose?.();
+
+            process.exit(1);
+        });
     });
 


### PR DESCRIPTION
### Fixes

* Fix non-zero exit codes were not being passed along, always resulting in `0`
* Processes erroring should exit, not reject
* Fix bug where environment variables were not getting passed along (e.g., `NODE_AUTH_TOKEN`)