### PR TITLE
feat: add example command and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Simply add these things to your **package.json**. All scripts (a.k.a., commands)
 | `upload` | Upload files to gh-pages branch |
 | `version` | Output the version of `@pixi/extension-scripts` |
 | `watch` | Watch the code in development mode, updates on changes |
+| `example` | Copy `dist` folder with the files generated on build step into `examples` folder and start http-server |
 
 ### Chaining
 

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -217,6 +217,7 @@ const Command = {
     Upload: 'upload',
     Version: 'version',
     Watch: 'watch',
+    Example: "example",
 };
 
 /** Workflow tasks */
@@ -319,6 +320,27 @@ const runCommand = async (command, additionalArgs) =>
             break;
         }
         case Command.Watch: bundle('-w'); break;
+        case Command.Example:
+            /**
+            * Copy the dist folder to the examples folder, so the files generated on build can be used on the examples.
+            * As this will be run on Plugin projects, the path reference will work as expected.
+            */
+            await promises.cp(
+            "./dist",
+            "./examples/dist",
+            { recursive: true },
+            (err) => {
+                if (err) {
+                console.error(err);
+                }
+            }
+            );
+
+            /**
+            * Start a local server to serve the examples
+            */
+            await spawn("http-server", [extensionConfig.serve]);
+            break;
         default: {
             // eslint-disable-next-line no-console
             console.error(chalk.red(`${prefix} Error: Unknown command "${command}". `


### PR DESCRIPTION
## Changes

My VSCode has autoformat enabled on save, I'll add the changes into this PR description to be easier.

* `lib/index.mjs`

```
/** Supported commands */
const Command = {
  Build: "build",
  Bump: "bump",
  Bundle: "bundle",
  Clean: "clean",
  Deploy: "deploy",
  Docs: "docs",
  GitPush: "git-push",
  Lint: "lint",
  Pack: "pack",
  Publish: "publish",
  Release: "release",
  Serve: "serve",
  Test: "test",
  Types: "types",
  Upload: "upload",
  Version: "version",
  Watch: "watch",
  Example: "example", <-------------- added
};


...


Case for Example command added.


    case Command.Example:
      /**
       * Copy the dist folder to the examples folder, so the files generated on build can be used on the examples.
       * As this will be run on Plugin projects, the path reference will work as expected.
       */
      await promises.cp(
        "./dist",
        "./examples/dist",
        { recursive: true },
        (err) => {
          if (err) {
            console.error(err);
          }
        }
      );
```

* `package.json`

Version updated to `"version": "2.5.0"`

## How to Test

* Add yalc globally: https://github.com/wclr/yalc

`npm i -g yalc`

* Checkout to this branch `git checkout feat/example-command`
* Publish the library locally: `yalc publish`. You should see the following message: `@pixi/extension-scripts@2.5.0 published in the store.`
* Go to the plugin project, ex: https://github.com/pixijs/tilemap
* Link the `xs` from the local registry into the project by running `yalc add @pixi/extension-scripts@2.5.0 --link`. the `--link` is to reflect all changes from the local registry, ex: I did one update on `xs` package, if it's already published I just need to run `yalc push`, with this command Yalc will push the change into the local registry for this package, with the `--link` this will be reflected to all local projects using this package with Yalc. 

PS: you should see the package reference like that: `"@pixi/extension-scripts": "link:.yalc/@pixi/extension-scripts",`

* Build the project: `npm run build`
* Add the following script into the package.json scripts object: `"example": "xs example",`.
* Run the example script `npm run example` (this should be run after the build, so the script will copy the `dist` folder to inside the `examples` folder).